### PR TITLE
fix installation error b/c of small letters in class names

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,8 +3,8 @@
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="add" xsi:type="object">Webfixit\CacheHostsManager\Console\Command\add</item>
-                <item name="remove" xsi:type="object">Webfixit\CacheHostsManager\Console\Command\remove</item>
+                <item name="add" xsi:type="object">Webfixit\CacheHostsManager\Console\Command\Add</item>
+                <item name="remove" xsi:type="object">Webfixit\CacheHostsManager\Console\Command\Remove</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
installation on M2.1.12 failed with following error
  [ReflectionException]
  Class Webfixit\CacheHostsManager\Console\Command\add does not exist
here is a fix